### PR TITLE
Can /#/classify redirect to the annotation interface

### DIFF
--- a/app/modules/ships/scripts/init.js
+++ b/app/modules/ships/scripts/init.js
@@ -8,7 +8,8 @@
 
     module.config([
         '$stateProvider',
-        function ($stateProvider) {
+        '$urlRouterProvider',
+        function ($stateProvider, $urlRouterProvider) {
             $stateProvider
                 .state('ships-list', {
                     url: '/ships',
@@ -34,6 +35,8 @@
                         }
                     }
                 });
+
+            $urlRouterProvider.when('/classify', '/ships');
         }
     ]);
 


### PR DESCRIPTION
This would help with standardizing links from the Talk interface vis: zooniverse/Panoptes-Front-End#1494
