### PR TITLE
Remove ng-load and replace with ng-attr-onload with interpolation

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -172,7 +172,6 @@
         <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
         <script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
         <script src="bower_components/angular-fitvids/angular-fitvids.js"></script>
-        <script src="bower_components/ng-load/ng-load.js"></script>
         <script src="bower_components/spin.js/spin.js"></script>
         <script src="bower_components/angular-spinner/angular-spinner.js"></script>
         <script src="bower_components/svg-pan-zoom/dist/svg-pan-zoom.js"></script>

--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -14,7 +14,6 @@
     var module = angular.module('transcribe', [
         'ngAnimate',
         'ui.router',
-        'ngLoad',
         'angularSpinner',
         'svg',
         'annotation'
@@ -505,7 +504,7 @@
                             // TODO: change this. We're cache busting the image.onload event.
                             subjectImage += '?' + new Date().getTime();
                             $scope.trustedSubjectImage = $sce.trustAsResourceUrl(subjectImage);
-
+                            $scope.loadHandler = $scope.subjectLoaded();
                             $rootScope.$broadcast('transcribe:loadedSubject');
                         });
                     } else {

--- a/app/modules/transcribe/templates/transcribe/transcribe.html
+++ b/app/modules/transcribe/templates/transcribe/transcribe.html
@@ -33,7 +33,7 @@
                                     <image subject class="subject"></image>
                                     <image
                                         xlink:href="{{ trustedSubjectImage }}"
-                                        ng-load="subjectLoaded(); svg.reset();"
+                                        ng-attr-onload="{{ loadHandler }} svg.reset();"
                                         width="1300"
                                         height="1893"
                                     ></image>

--- a/app/modules/transcription/scripts/init.js
+++ b/app/modules/transcription/scripts/init.js
@@ -3,7 +3,6 @@
 
     var module = angular.module('transcription', [
         'ui.router',
-        'ngLoad',
         'angularSpinner'
     ]);
 
@@ -59,6 +58,7 @@
                         var subjectImage = subject.locations[0][keys[0]];
                         subjectImage += '?' + new Date().getTime();
                         $scope.subjectImage = $sce.trustAsResourceUrl(subjectImage);
+                        $scope.loadHandler = $scope.subjectLoaded();
                     });
             } else {
                 $scope.annotations = null;

--- a/app/modules/transcription/templates/transcription/transcription.html
+++ b/app/modules/transcription/templates/transcription/transcription.html
@@ -29,7 +29,7 @@
                 <g class="image">
                     <image
                     xlink:href="{{ subjectImage }}"
-                    ng-load="subjectLoaded(); svg.reset();"
+                    ng-attr-onload="{{ loadHandler }} svg.reset();"
                     width="1300"
                     height="1893"
                     ></image>

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     "lodash": "3.10.0",
     "angular-bootstrap": "0.12.1",
     "svg-pan-zoom": "3.1.3",
-    "ng-load": "1.0.2",
     "angular-spinner": "0.6.1",
     "spin.js": "2.3.0",
     "animate.css": "3.3.0",


### PR DESCRIPTION
Fixed #77:
- Removed `ng-load` and replaced with `ng-attr-onload` in the two places I found it.
- Interpolating in a handler, which throws `Interpolations for HTML DOM event attributes are disallowed.  Please use the ng- versions (such as ng-click instead of onclick) instead.` in the console, but it doesn't stop the app from working. I tried without the interpolation and it didn't work in IE11. With it, the subject load and isLoading state update works in IE11 and Edge.
- Chrome and FF still working fine.
