### PR TITLE
Misc. Fixes

### DIFF
--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -422,7 +422,7 @@
                 return zooAPI.type('subjects').get({
                     sort: 'queued',
                     workflow_id: project.links.workflows[0],
-                    page: lastPage + 1,
+                    // page: lastPage + 1,
                     page_size: 20,
                     subject_set_id: subject_set_id
                 }).then(function (res) {

--- a/styl/main.styl
+++ b/styl/main.styl
@@ -159,6 +159,7 @@ img
 
 
 #site-main
+    min-height: 480px // prevent from collapsing
     position: relative
 
 #site-footer


### PR DESCRIPTION
Implements the following fixes: 
- Prevents content collapsing to reveal the footer by setting `min-height: 480px` in `#site-main`. It pads the content while it loads so the footer will remain "below the fold". See #97.
- Stops setting incorrect `page` parameter when fetching subjects. It was computing a `lastPage` value that resulted in requesting a page that had already been seen, so the returned subject array was empty. Resolves #94.
