### PR TITLE
Use panoptes-client from npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ templates.js
 .tmp/
 coverage/
 node_modules/
+app/panoptes-client.js

--- a/app/index.html
+++ b/app/index.html
@@ -176,7 +176,7 @@
         <script src="bower_components/svg-pan-zoom/dist/svg-pan-zoom.js"></script>
         <script src="bower_components/packery/dist/packery.pkgd.js"></script>
 
-        <script src="bower_components/panoptes-javascript-lib/dist/panoptes-javascript-lib.js"></script>
+        <script src="panoptes-client.js"></script>
 
         <script src="modules/app/scripts/init.js"></script>
         <script src="modules/app/scripts/home-controller.js"></script>
@@ -227,6 +227,8 @@
 
         <script src="modules/zooniverse/scripts/init.js"></script>
         <script src="modules/zooniverse/scripts/zooniverse-footer.factory.js"></script>
+        <script src="modules/zooniverse/scripts/zooniverse-footer.directive.js"></script>
+
         <script src="modules/zooniverse/scripts/zooniverse-footer.directive.js"></script>
         <!-- endbuild -->
 

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "angular-spinner": "0.6.1",
     "spin.js": "2.3.0",
     "animate.css": "3.3.0",
-    "panoptes-javascript-lib": "0.0.3",
     "angular-local-storage": "0.2.2",
     "masonry": "3.3.1",
     "packery": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "postinstall": "bower install && gulp hookmeup",
+    "postinstall": "bower install && browserify panoptes-client-wrapper/index.js > app/panoptes-client.js && gulp hookmeup",
     "test": "gulp test-ci"
   },
   "repository": {
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/zooniverse/old-weather",
   "devDependencies": {
     "bower": "^1.7.9",
+    "browserify": "^13.0.1",
     "gulp": "^3.8.11",
     "gulp-angular-templatecache": "^1.6.0",
     "gulp-chmod": "1.2.0",
@@ -46,7 +47,9 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "0.3.5",
     "nib": "1.1.0",
+    "panoptes-client": "^2.5.1",
     "run-sequence": "^1.1.0",
     "stylus": "^0.51.1"
-  }
+  },
+  "dependencies": {}
 }

--- a/panoptes-client-wrapper/index.js
+++ b/panoptes-client-wrapper/index.js
@@ -1,0 +1,2 @@
+window.zooAPI = require('panoptes-client/lib/api-client');
+window.zooAuth = require('panoptes-client/lib/auth');


### PR DESCRIPTION
Builds a browser bundle from the panoptes-client npm module after installing, making the api and auth clients available at `window.zooAPI` and `window.zooAuth` respectively. Haven't tested the auth yet, but I think OW does it's own thing rather than use an auth library, so worth checking that.
