### PR TITLE
Save annotations as partial classifications, pick them up in transcription phase.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -163,8 +163,10 @@
             </div>
         </footer>
 
-        <script src="https://cdn.polyfill.io/v2/polyfill.js?unknown=polyfill&amp;features=default,Promise&amp;flags=gated"></script>
+        <script src="https://cdn.polyfill.io/v2/polyfill.js?unknown=polyfill&amp;features=default&amp;flags=gated"></script>
         <!-- build:js scripts/app.js -->
+        <script src="bower_components/setimmediate2/dist/setImmediate.js"></script>
+        <script src="bower_components/promise-polyfill/promise.js"></script>
         <script src="bower_components/lodash/lodash.js"></script>
         <script src="bower_components/angular/angular.js"></script>
         <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>

--- a/app/modules/annotation/scripts/annotations-factory-service.js
+++ b/app/modules/annotation/scripts/annotations-factory-service.js
@@ -92,7 +92,7 @@
             } else {
 
                 classification.metadata.finished_at = new Date().toISOString();
-                classification.completed = true;
+                classification.completed = false;
 
                 var resource = zooAPI.type('classifications').create(classification);
                 resource.save()

--- a/app/modules/transcription/scripts/init.js
+++ b/app/modules/transcription/scripts/init.js
@@ -57,6 +57,18 @@
     module.controller('transcriptionCtrl', function ($rootScope, $q, $timeout, $scope, $sce, $stateParams, zooAPI, zooAPISubjectSets, localStorageService, svgPanZoomFactory, pendingAnnotationsService) {
         $rootScope.bodyClass = 'transcribe';
 
+        function zoomToCurrentAnnotation() {
+            if ($scope.annotations && $scope.annotations.length > 0) {
+                var annotation = $scope.annotations[0];
+                var obj = svgPanZoomFactory.zoomToRect(annotation);
+
+                $scope.uiPositionTop = (obj.sizes.height / 2) + ((annotation.height * obj.sizes.realZoom) / 2);
+                $scope.annotationContent = $scope.annotations[0].content;
+            }
+        }
+
+        window.zoomToCurrentAnnotation = zoomToCurrentAnnotation;
+
         var subject_set_id = $stateParams.subject_set_id;
         zooAPISubjectSets.get({id: subject_set_id})
             .then(function (response) {
@@ -114,18 +126,12 @@
 
                 load_next();
 
-                $scope.$watch('annotations', function () {
-                    if ($scope.annotations && $scope.annotations.length > 0) {
-                        var annotation = $scope.annotations[0];
-                        var obj = svgPanZoomFactory.zoomToRect(annotation);
-
-                        $scope.uiPositionTop = (obj.sizes.height / 2) + ((annotation.height * obj.sizes.realZoom) / 2);
-                        $scope.annotationContent = $scope.annotations[0].content;
-                    }
-                }, true);
+                $scope.$watch('annotations', zoomToCurrentAnnotation, true);
 
                 $scope.subjectLoaded = function () {
                     $scope.isLoading = false;
+                    // Image is loaded, we can safely calculate zoom for first annotation
+                    $timeout(zoomToCurrentAnnotation, 0);
                 };
 
                 $scope.prevAnnotation = function () {

--- a/app/modules/transcription/scripts/init.js
+++ b/app/modules/transcription/scripts/init.js
@@ -19,13 +19,15 @@
             });
     });
 
-    module.controller('transcriptionCtrl', function ($rootScope, $q, $timeout, $scope, $sce, $stateParams, zooAPI, zooAPISubjectSets, localStorageService, svgPanZoomFactory) {
+    module.service('pendingAnnotationsService', ['zooAPI', function(zooAPI) {
+        this.get = function(page) {
+            return zooAPI.type('classifications/incomplete').get({ page: page || 1 })
+        };
+    }]);
 
+    module.controller('transcriptionCtrl', function ($rootScope, $q, $timeout, $scope, $sce, $stateParams, zooAPI, zooAPISubjectSets, localStorageService, svgPanZoomFactory, pendingAnnotationsService) {
+        console.log('transcription');
         $rootScope.bodyClass = 'transcribe';
-
-        var getIncompletes = function (page) {
-            return zooAPI.type('classifications/incomplete').get({ page: page || 1 });
-        }
 
         var subject_set_id = $stateParams.subject_set_id;
         zooAPISubjectSets.get({id: subject_set_id})
@@ -40,7 +42,7 @@
         });
         var annotations_for_subject_set = _.where(annotations_list, {subject_set_id: subject_set_id});
 
-        getIncompletes()
+        pendingAnnotationsService.get()
             .then(function (annotations_for_subject_set) {
 
                 $scope.showAllAnnotations = false;

--- a/app/modules/transcription/scripts/init.js
+++ b/app/modules/transcription/scripts/init.js
@@ -70,6 +70,7 @@
         window.zoomToCurrentAnnotation = zoomToCurrentAnnotation;
 
         var subject_set_id = $stateParams.subject_set_id;
+        $scope.isLoading = true;
         zooAPISubjectSets.get({id: subject_set_id})
             .then(function (response) {
                 $scope.ship = response[0];

--- a/app/modules/transcription/scripts/init.js
+++ b/app/modules/transcription/scripts/init.js
@@ -175,14 +175,16 @@
                 };
 
                 $scope.finish = function () {
+                    $scope.save();
                     $scope.classification.update({
-                        metadata: {
-                            started_at: new Date().toISOString(),
-                            finished_at: new Date().toISOString(),
-                            completed: true,
-                            user_agent: navigator.userAgent,
-                            user_language: navigator.language
-                        }
+                      completed: true, // otherwise classification remains incomplete!
+                      annotations: $scope.annotations,
+                      metadata: {
+                          started_at: new Date().toISOString(),
+                          finished_at: new Date().toISOString(),
+                          user_agent: navigator.userAgent,
+                          user_language: navigator.language
+                      }
                     });
 
                     $scope.classification.save()

--- a/app/modules/transcription/scripts/init.js
+++ b/app/modules/transcription/scripts/init.js
@@ -20,14 +20,18 @@
     });
 
     module.controller('transcriptionCtrl', function ($rootScope, $q, $timeout, $scope, $sce, $stateParams, zooAPI, zooAPISubjectSets, localStorageService, svgPanZoomFactory) {
-        
+
         $rootScope.bodyClass = 'transcribe';
+
+        var getIncompletes = function (page) {
+            return zooAPI.type('classifications/incomplete').get({ page: page || 1 });
+        }
 
         var subject_set_id = $stateParams.subject_set_id;
         zooAPISubjectSets.get({id: subject_set_id})
             .then(function (response) {
                 $scope.ship = response[0];
-            });
+            })
 
         var annotations_list = localStorageService.get('annotations_list');
         // Only return items that have a classification.
@@ -36,142 +40,146 @@
         });
         var annotations_for_subject_set = _.where(annotations_list, {subject_set_id: subject_set_id});
 
-        $scope.showAllAnnotations = false;
+        getIncompletes()
+            .then(function (annotations_for_subject_set) {
 
-        var load_next = function () {
-            $scope.subjectImage = null;
-            $scope.isLoading = true;
+                $scope.showAllAnnotations = false;
 
-            if (annotations_for_subject_set.length > 0) {
-                var subject_id = annotations_for_subject_set[0].subject_id;
-                $scope.subject_id = subject_id;
-                annotations_for_subject_set.shift();
+                var load_next = function () {
+                    $scope.subjectImage = null;
+                    $scope.isLoading = true;
 
-                var annotation = localStorageService.get('annotation_subject_id_' + subject_id);
-                $scope.annotations = annotation.annotations;
+                    if (annotations_for_subject_set.length > 0) {
+                        var subject_id = annotations_for_subject_set[0].links.subjects[0];
+                        $scope.subject_id = subject_id;
+                        annotations_for_subject_set.shift();
 
-                // Our best friend $timeout is back. Used here to delay setting 
-                // of first / last until the $$hashKey has been set.
-                $timeout(function() {
-                    $scope.first = $scope.annotations[0].$$hashKey;
-                    $scope.last = $scope.annotations[$scope.annotations.length - 1].$$hashKey;
-                }, 0);
-                
-                // This is presumably to allow saving of header rows, but this 
-                // feature never got implemented. I'm not quite sure why there 
-                // are separate entries for rows and cells (possibly to create 
-                // subsequent rows off the columns), but we want to be able to 
-                // transcribe the header cells for now.
-                // _.remove($scope.annotations, {type: 'header'});
+                        var annotation = localStorageService.get('annotation_subject_id_' + subject_id);
+                        $scope.annotations = annotation.annotations;
 
-                _.remove($scope.annotations, {type: 'row'});
-
-                zooAPI.type('subjects').get({id: subject_id})
-                    .then(function (response) {
-                        var subject = response[0];
-                        var keys = Object.keys(subject.locations[0]);
-                        var subjectImage = subject.locations[0][keys[0]];
-                        subjectImage += '?' + new Date().getTime();
-                        $timeout(function () {
-                            $scope.subjectImage = $sce.trustAsResourceUrl(subjectImage);
-                            $scope.loadHandler = $scope.subjectLoaded();
+                        // Our best friend $timeout is back. Used here to delay setting
+                        // of first / last until the $$hashKey has been set.
+                        $timeout(function() {
+                            $scope.first = $scope.annotations[0].$$hashKey;
+                            $scope.last = $scope.annotations[$scope.annotations.length - 1].$$hashKey;
                         }, 0);
-                    });
-            } else {
-                $scope.annotations = null;
-                $scope.isLoading = false;
-            }
-        };
 
-        load_next();
+                        // This is presumably to allow saving of header rows, but this
+                        // feature never got implemented. I'm not quite sure why there
+                        // are separate entries for rows and cells (possibly to create
+                        // subsequent rows off the columns), but we want to be able to
+                        // transcribe the header cells for now.
+                        // _.remove($scope.annotations, {type: 'header'});
 
-        $scope.$watch('annotations', function () {
-            if ($scope.annotations && $scope.annotations.length > 0) {
-                var annotation = $scope.annotations[0];
-                var obj = svgPanZoomFactory.zoomToRect(annotation);
+                        _.remove($scope.annotations, {type: 'row'});
 
-                $scope.uiPositionTop = (obj.sizes.height / 2) + ((annotation.height * obj.sizes.realZoom) / 2);
-                $scope.annotationContent = $scope.annotations[0].content;
-            }
-        }, true);
+                        zooAPI.type('subjects').get({id: subject_id})
+                            .then(function (response) {
+                                var subject = response[0];
+                                var keys = Object.keys(subject.locations[0]);
+                                var subjectImage = subject.locations[0][keys[0]];
+                                subjectImage += '?' + new Date().getTime();
+                                $timeout(function () {
+                                    $scope.subjectImage = $sce.trustAsResourceUrl(subjectImage);
+                                    $scope.loadHandler = $scope.subjectLoaded();
+                                }, 0);
+                            });
+                    } else {
+                        $scope.annotations = null;
+                        $scope.isLoading = false;
+                    }
+                };
 
-        $scope.subjectLoaded = function () {
-            $scope.isLoading = false;
-        };
+                load_next();
 
-        $scope.prevAnnotation = function () {
-            $scope.save();
-            $scope.annotations.unshift($scope.annotations.pop());
-        };
+                $scope.$watch('annotations', function () {
+                    if ($scope.annotations && $scope.annotations.length > 0) {
+                        var annotation = $scope.annotations[0];
+                        var obj = svgPanZoomFactory.zoomToRect(annotation);
 
-        $scope.nextAnnotation = function () {
-            $scope.save();
-            $scope.annotations.push($scope.annotations.shift());
-        };
+                        $scope.uiPositionTop = (obj.sizes.height / 2) + ((annotation.height * obj.sizes.realZoom) / 2);
+                        $scope.annotationContent = $scope.annotations[0].content;
+                    }
+                }, true);
 
-        $scope.save = function () {
-            $scope.annotations[0].content = $scope.annotationContent;
-            $scope.annotationContent = null;
-        };
+                $scope.subjectLoaded = function () {
+                    $scope.isLoading = false;
+                };
 
-        $scope.toggleAllAnnotations = function () {
-            $scope.showAllAnnotations = true;
-            $scope.panZoom.fit();
-            $scope.panZoom.center();
-        };
+                $scope.prevAnnotation = function () {
+                    $scope.save();
+                    $scope.annotations.unshift($scope.annotations.pop());
+                };
 
-        var annotationInput = document.getElementById('annotation-input');
+                $scope.nextAnnotation = function () {
+                    $scope.save();
+                    $scope.annotations.push($scope.annotations.shift());
+                };
 
-        $scope.insertChar = function (insertValue) {
-            var input = annotationInput;
-            if (document.selection) {
-                input.focus();
-                document.selection.createRange().text = insertValue;
-            } else if (input.selectionStart || input.selectionStart === '0') {
-                var endPos = input.selectionStart + 1;
-                input.value = input.value.substring(0, input.selectionStart) + insertValue + input.value.substring(input.selectionEnd, input.value.length);
-                input.selectionStart = endPos;
-                input.selectionEnd = endPos;
-                input.focus();
-            } else {
-                input.value += insertValue;
-            }
-        };
+                $scope.save = function () {
+                    $scope.annotations[0].content = $scope.annotationContent;
+                    $scope.annotationContent = null;
+                };
 
-        $scope.finish = function () {
-            var obj = {
-                annotations: $scope.annotations,
-                metadata: {
-                    started_at: new Date().toISOString(),
-                    user_agent: navigator.userAgent,
-                    user_language: navigator.language
-                },
-                links: {
-                    project: $scope.ship.links.project,
-                    subjects: [$scope.subject_id]
-                }
-            };
+                $scope.toggleAllAnnotations = function () {
+                    $scope.showAllAnnotations = true;
+                    $scope.panZoom.fit();
+                    $scope.panZoom.center();
+                };
 
-            zooAPI.type('workflows').get({id: $scope.ship.links.workflows[0]})
-                .then(function (response) {
-                    var workflow = response[0];
-                    obj.links.workflow = workflow.id;
-                    obj.metadata.workflow_version = workflow.version;
+                var annotationInput = document.getElementById('annotation-input');
 
-                    obj.metadata.finished_at = new Date().toISOString();
-                    obj.completed = true;
+                $scope.insertChar = function (insertValue) {
+                    var input = annotationInput;
+                    if (document.selection) {
+                        input.focus();
+                        document.selection.createRange().text = insertValue;
+                    } else if (input.selectionStart || input.selectionStart === '0') {
+                        var endPos = input.selectionStart + 1;
+                        input.value = input.value.substring(0, input.selectionStart) + insertValue + input.value.substring(input.selectionEnd, input.value.length);
+                        input.selectionStart = endPos;
+                        input.selectionEnd = endPos;
+                        input.focus();
+                    } else {
+                        input.value += insertValue;
+                    }
+                };
 
-                    var resource = zooAPI.type('classifications').create(obj);
-                    resource.save()
+                $scope.finish = function () {
+                    var obj = {
+                        annotations: $scope.annotations,
+                        metadata: {
+                            started_at: new Date().toISOString(),
+                            user_agent: navigator.userAgent,
+                            user_language: navigator.language
+                        },
+                        links: {
+                            project: $scope.ship.links.project,
+                            subjects: [$scope.subject_id]
+                        }
+                    };
+
+                    zooAPI.type('workflows').get({id: $scope.ship.links.workflows[0]})
                         .then(function (response) {
-                            var annotations_list = localStorageService.get('annotations_list');
-                            _.remove(annotations_list, {subject_id: $scope.subject_id, subject_set_id: $stateParams.subject_set_id});
-                            localStorageService.set('annotations_list', annotations_list);
-                            localStorageService.remove('annotation_subject_id_' + $scope.subject_id);
-                            $scope.$apply(load_next);
+                            var workflow = response[0];
+                            obj.links.workflow = workflow.id;
+                            obj.metadata.workflow_version = workflow.version;
+
+                            obj.metadata.finished_at = new Date().toISOString();
+                            obj.completed = true;
+
+                            var resource = zooAPI.type('classifications').create(obj);
+                            resource.save()
+                                .then(function (response) {
+                                    var annotations_list = localStorageService.get('annotations_list');
+                                    _.remove(annotations_list, {subject_id: $scope.subject_id, subject_set_id: $stateParams.subject_set_id});
+                                    localStorageService.set('annotations_list', annotations_list);
+                                    localStorageService.remove('annotation_subject_id_' + $scope.subject_id);
+                                    $scope.$apply(load_next);
+                                });
                         });
-                });
-        };
+                };
+        });
     });
 
 }(window.angular, window._));

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,9 @@
     "masonry": "3.3.1",
     "packery": "1.4.1",
     "bootstrap": "3.3.5",
-    "angular-fitvids": "git@github.com:jimmyhillis/angular-fitvids.git#cfc155df7d13e1d6bf8029b08bb294df5025f84b"
+    "angular-fitvids": "git@github.com:jimmyhillis/angular-fitvids.git#cfc155df7d13e1d6bf8029b08bb294df5025f84b",
+    "setimmediate2": "^2.0.1",
+    "promise-polyfill": "^5.2.1"
   },
   "resolutions": {
     "angular": "1.4.1",


### PR DESCRIPTION
TODO: only fetch partial classifications for the current subject set

This is a basic proof of concept. Currently, annotations and classifications are submitted as separate classifications. This PR instead saves annotations as partial classifications which the transcription phase picks up from api/classifications/incomplete (see http://docs.panoptes.apiary.io/#reference/classification/classification-collection/list-all-classifications). 

Currently I haven't figured out how we limit these to the current subject set (i.e. ship) - we can't do it using the API I don't think. We might be able to include subjects in the classification request though, and then filter client-side as the subjects will have a subject set id in. Would need a loop which requests classifications from the API until we have at least one for the current set (or until there are no more classifications, in which case we show the "nothing to transcribe" notice as occurs currently).

Eventually I think we can cut out the localStorageService layer for most things, as I believe panoptes-client caches non-query requests.
