### PR TITLE
temporary fix for lingering workflow ids in project.links

### DIFF
--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -317,7 +317,7 @@
             var deferred = $q.defer();
             zooAPISubjectSets.get({id: subject_set_id})
                 .then(function (response) {
-                    var workflowID = response[0].links.workflows[0];
+                    var workflowID = response[0].links.workflows[0]; // Note: Defaulting to first workflow may cause unexpected issues
                     zooAPIWorkflows.get(workflowID)
                         .then(addReuseGridTask)
                         .then(deferred.resolve, deferred.reject, deferred.notify);
@@ -421,7 +421,7 @@
             var _getSubjectsPage = function (project) {
                 return zooAPI.type('subjects').get({
                     sort: 'queued',
-                    workflow_id: project.links.workflows[0],
+                    workflow_id: project.configuration.default_workflow, //project.links.workflows[0],
                     // page: lastPage + 1,
                     page_size: 20,
                     subject_set_id: subject_set_id


### PR DESCRIPTION
Deleted workflow ids aren't cleared from `project.links`

Detailed description: I created a couple of new workflows that I subsequently deleted. Unfortunately, they remain in `project.links` and, in fact, bumped the previous workflow id, so when it gets referenced as `project.links.workflows[0]` it ends up returning a non-existent workflow. I noticed there is a checkbox to set a "default workflow" in the project builder. I've decided to use this so that `project.configuration.default_workflow` will always point to the same workflow.
