### PR TITLE
Delete rows

### DIFF
--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -158,16 +158,12 @@
               var annotation = $parse(attrs.annotation)(scope);
 
               var params = {
-                  message: 'Delete annotation?'
+                  message:    annotation.type === 'row_annotation' ? 'Delete annotation or entire row?' : 'Delete annotation?',
+                  deleteType: annotation.type === 'row_annotation' ? 'row' : 'row_annotation'
               };
 
-              // var message = 'Delete annotation?'
-
-              if(annotation.type == 'row_annotation') {
-                params.message = 'Delete row or annotation?';
-              }
-
-              confirmationModalFactory.deployModal(params, function(deleteType){
+              confirmationModalFactory.setParams(params);
+              confirmationModalFactory.deployModal(function(deleteType){
                 console.log('deleteType = ', deleteType); // --STI
                 if(deleteType == 'row'){
                   scope.$parent.removeAnnotation(annotation, 'row');

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -28,22 +28,6 @@
                     scope.$apply();
                 };
 
-                var storeAnnotations = function (e, data) {
-                    // skip for row annotation: createCells() called separately
-                    if (data.type === 'row') {
-                      createCells(data);
-                    }
-                    else {
-                      var existing = _.find(scope.annotations, {_id: data._id});
-                      if (angular.isUndefined(existing)) {
-                          addAnnotation(data);
-                      } else {
-                          updateAnnotation(data, existing);
-                      }
-                    }
-
-                };
-
                 var tempCells = {};
 
                 var createCells = function (row) {
@@ -78,6 +62,22 @@
                     });
                 };
 
+                var storeAnnotations = function (e, data) {
+                    // skip for row annotation: createCells() called separately
+                    if (data.type === 'row') {
+                      createCells(data);
+                    }
+                    else {
+                      var existing = _.find(scope.annotations, {_id: data._id});
+                      if (angular.isUndefined(existing)) {
+                          addAnnotation(data);
+                      } else {
+                          updateAnnotation(data, existing);
+                      }
+                    }
+
+                };
+
                 var getAnnotations = function () {
                     scope.annotations = [];
 
@@ -99,7 +99,7 @@
                 };
 
                 scope.removeAnnotation = function (annotation, type) {
-                    if(type == 'row' && annotation._rowId) { // remove all annotations in row
+                    if(type === 'row' && annotation._rowId) { // remove all annotations in row
                       var annotationsToRemove = _.filter(scope.annotations, {_rowId: annotation._rowId});
                       for(var currAnnotation of annotationsToRemove) {
                         _.remove(scope.annotations, {_rowId: currAnnotation._rowId});
@@ -164,10 +164,9 @@
 
               confirmationModalFactory.setParams(params);
               confirmationModalFactory.deployModal(function(deleteType){
-                console.log('deleteType = ', deleteType); // --STI
-                if(deleteType == 'row'){
+                if(deleteType === 'row'){
                   scope.$parent.removeAnnotation(annotation, 'row');
-                } else if(deleteType == 'annotation') {
+                } else if(deleteType === 'annotation') {
                   scope.$parent.removeAnnotation(annotation, 'annotation');
                 }
               });

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -90,8 +90,10 @@
                 };
 
                 var clearAnnotations = function () {
-                  confirmationModalFactory.deployModal({message: 'Clear all annotations?'}, function(isConfirmed){
-                    if(isConfirmed){
+                  var params = {message: 'Clear all annotations?'};
+                  confirmationModalFactory.setParams(params);
+                  confirmationModalFactory.deployModal(function(deleteType){
+                    if(deleteType){
                       scope.annotations = [];
                       annotationsFactory.clear(null, scope.$parent.subject);
                     }
@@ -163,7 +165,10 @@
               };
 
               confirmationModalFactory.setParams(params);
-              confirmationModalFactory.deployModal(function(deleteType){
+              confirmationModalFactory.deployModal( function(deleteType) {
+                if(!deleteType) {
+                  return; // no params passed, nothing to do
+                }
                 if(deleteType === 'row'){
                   scope.$parent.removeAnnotation(annotation, 'row');
                 } else if(deleteType === 'annotation') {

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -29,6 +29,7 @@
                 };
 
                 var storeAnnotations = function (e, data) {
+                    console.log('storeAnnotations(), data = ', data); // --STI
                     var existing = _.find(scope.annotations, {_id: data._id});
                     if (angular.isUndefined(existing)) {
                         addAnnotation(data);
@@ -40,30 +41,32 @@
                 var tempCells = {};
 
                 var createCells = function (row) {
+                    console.log('createCells() '); // --STI
                     var headers = _.where(scope.annotations, {type: 'header'});
                     var rowId = _.uniqueId('row_');
                     _.each(headers, function (header, index) {
                         // If the row is below the header
                         if (row.y >= (header.y + header.height)) {
-                            var obj = {
+                            var annotation = {
                                 height: row.height,
                                 width: header.width,
                                 x: header.x,
                                 y: row.y,
-                                rotation: header.rotation
+                                rotation: header.rotation,
+                                type: 'row_tmp'
                             };
 
                             var existing = _.find(scope.annotations, { _id: tempCells[index] });
 
                             if (angular.isUndefined(existing)) {
-                                obj._id = _.uniqueId() + new Date().getTime();
-                                obj._rowId = rowId;
-                                addAnnotation(obj);
-                                tempCells[index] = obj._id;
+                                annotation._id = _.uniqueId('antn_'); //+ new Date().getTime();
+                                annotation._rowId = rowId;
+                                addAnnotation(annotation);
+                                tempCells[index] = annotation._id;
                             } else {
-                                obj._id = existing._id;
-                                obj._rowId = existing._rowId;
-                                updateAnnotation(obj, existing);
+                                annotation._id = existing._id;
+                                annotation._rowId = existing._rowId;
+                                updateAnnotation(annotation, existing);
                             }
 
                         }
@@ -150,6 +153,7 @@
             element.bind('mousedown', function (e) {
               e.stopPropagation();
               var annotation = $parse(attrs.annotation)(scope);
+              console.log('ANNOTATION.TYPE = ', annotation.type); // --STI
               confirmationModalFactory.deployModal('Delete annotation?', function(isConfirmed){
                 if(isConfirmed){
                   scope.$parent.removeAnnotation(annotation);

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -41,6 +41,7 @@
 
                 var createCells = function (row) {
                     var headers = _.where(scope.annotations, {type: 'header'});
+                    var rowId = _.uniqueId('row_');
                     _.each(headers, function (header, index) {
                         // If the row is below the header
                         if (row.y >= (header.y + header.height)) {
@@ -56,12 +57,15 @@
 
                             if (angular.isUndefined(existing)) {
                                 obj._id = _.uniqueId() + new Date().getTime();
+                                obj._rowId = rowId;
                                 addAnnotation(obj);
                                 tempCells[index] = obj._id;
                             } else {
                                 obj._id = existing._id;
+                                obj._rowId = existing._rowId;
                                 updateAnnotation(obj, existing);
                             }
+
                         }
                     });
                 };
@@ -87,9 +91,18 @@
                 };
 
                 scope.removeAnnotation = function (annotation) {
-                    _.remove(scope.annotations, {_id: annotation._id});
-                    annotationsFactory.remove(annotation._id, scope.$parent.subject);
-                    
+                    if(annotation._rowId) { // remove all annotations in row
+                      console.log('THIS ANNOTATION IS PART OF A ROW: ', annotation._rowId);
+                      var annotationsToRemove = _.filter(scope.annotations, {_rowId: annotation._rowId});
+                      console.log('REMOVING: ', annotationsToRemove);
+                      for(var currAnnotation of annotationsToRemove) {
+                        _.remove(scope.annotations, {_rowId: currAnnotation._rowId});
+                        annotationsFactory.remove(currAnnotation._id, scope.$parent.subject);
+                      }
+                    } else {
+                      _.remove(scope.annotations, {_id: annotation._id});
+                      annotationsFactory.remove(annotation._id, scope.$parent.subject);
+                    }
                     scope.$apply();
                 };
 

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -90,7 +90,7 @@
                 };
 
                 var clearAnnotations = function () {
-                  confirmationModalFactory.deployModal('Clear all annotations?', function(isConfirmed){
+                  confirmationModalFactory.deployModal({message: 'Clear all annotations?'}, function(isConfirmed){
                     if(isConfirmed){
                       scope.annotations = [];
                       annotationsFactory.clear(null, scope.$parent.subject);
@@ -98,8 +98,8 @@
                   });
                 };
 
-                scope.removeAnnotation = function (annotation) {
-                    if(annotation._rowId) { // remove all annotations in row
+                scope.removeAnnotation = function (annotation, type) {
+                    if(type == 'row' && annotation._rowId) { // remove all annotations in row
                       var annotationsToRemove = _.filter(scope.annotations, {_rowId: annotation._rowId});
                       for(var currAnnotation of annotationsToRemove) {
                         _.remove(scope.annotations, {_rowId: currAnnotation._rowId});
@@ -156,13 +156,23 @@
             element.bind('mousedown', function (e) {
               e.stopPropagation();
               var annotation = $parse(attrs.annotation)(scope);
-              var message = 'Delete annotation?'
+
+              var params = {
+                  message: 'Delete annotation?'
+              };
+
+              // var message = 'Delete annotation?'
+
               if(annotation.type == 'row_annotation') {
-                message = 'Delete entire row?';
+                params.message = 'Delete row or annotation?';
               }
-              confirmationModalFactory.deployModal(message, function(isConfirmed){
-                if(isConfirmed){
-                  scope.$parent.removeAnnotation(annotation);
+
+              confirmationModalFactory.deployModal(params, function(deleteType){
+                console.log('deleteType = ', deleteType); // --STI
+                if(deleteType == 'row'){
+                  scope.$parent.removeAnnotation(annotation, 'row');
+                } else if(deleteType == 'annotation') {
+                  scope.$parent.removeAnnotation(annotation, 'annotation');
                 }
               });
             });

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -29,19 +29,28 @@
                 };
 
                 var storeAnnotations = function (e, data) {
+                    console.log('storeAnnotations(), data = ', data);
                     // skip for row annotation: createCells() called separately
-                    if (data.type === 'row') return;
-                    var existing = _.find(scope.annotations, {_id: data._id});
-                    if (angular.isUndefined(existing)) {
-                        addAnnotation(data);
-                    } else {
-                        updateAnnotation(data, existing);
+                    if (data.type === 'row') {
+                      console.log('CREATING CELLS!');
+                      createCells(data);
                     }
+                    else {
+                      console.log('SINGLE SELL');
+                      var existing = _.find(scope.annotations, {_id: data._id});
+                      if (angular.isUndefined(existing)) {
+                          addAnnotation(data);
+                      } else {
+                          updateAnnotation(data, existing);
+                      }
+                    }
+
                 };
 
                 var tempCells = {};
 
                 var createCells = function (row) {
+                    console.log('createCells(), row = ', row);
                     var headers = _.where(scope.annotations, {type: 'header'});
                     var rowId = _.uniqueId('row_'); // + new Date().getTime(); // use human-readable id for debugging --STI
                     _.each(headers, function (header, index) {
@@ -128,13 +137,13 @@
 
                 scope.$on('svgDrawing:update', function (e, rect, data) {
                     if (data.type === 'row') {
-                        createCells(rect);
+                        // createCells(rect);
                     }
                 });
 
                 scope.$on('svgDrawing:finish', function (e, rect, data) {
                     if (data.type === 'row') {
-                        createCells(rect);
+                        // createCells(rect);
                     }
                     tempCells = {};
                 });

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -29,7 +29,8 @@
                 };
 
                 var storeAnnotations = function (e, data) {
-                    console.log('storeAnnotations(), data = ', data); // --STI
+                    // skip for row annotation: createCells() called separately
+                    if (data.type === 'row') return;
                     var existing = _.find(scope.annotations, {_id: data._id});
                     if (angular.isUndefined(existing)) {
                         addAnnotation(data);
@@ -41,9 +42,8 @@
                 var tempCells = {};
 
                 var createCells = function (row) {
-                    console.log('createCells() '); // --STI
                     var headers = _.where(scope.annotations, {type: 'header'});
-                    var rowId = _.uniqueId('row_');
+                    var rowId = _.uniqueId('row_'); // + new Date().getTime(); // use human-readable id for debugging --STI
                     _.each(headers, function (header, index) {
                         // If the row is below the header
                         if (row.y >= (header.y + header.height)) {
@@ -53,13 +53,13 @@
                                 x: header.x,
                                 y: row.y,
                                 rotation: header.rotation,
-                                type: 'row_tmp'
+                                type: 'row'
                             };
 
                             var existing = _.find(scope.annotations, { _id: tempCells[index] });
 
                             if (angular.isUndefined(existing)) {
-                                annotation._id = _.uniqueId('antn_'); //+ new Date().getTime();
+                                annotation._id = _.uniqueId('antn_'); //+ new Date().getTime(); // use human-readable id for debugging --STI
                                 annotation._rowId = rowId;
                                 addAnnotation(annotation);
                                 tempCells[index] = annotation._id;
@@ -95,9 +95,7 @@
 
                 scope.removeAnnotation = function (annotation) {
                     if(annotation._rowId) { // remove all annotations in row
-                      console.log('THIS ANNOTATION IS PART OF A ROW: ', annotation._rowId);
                       var annotationsToRemove = _.filter(scope.annotations, {_rowId: annotation._rowId});
-                      console.log('REMOVING: ', annotationsToRemove);
                       for(var currAnnotation of annotationsToRemove) {
                         _.remove(scope.annotations, {_rowId: currAnnotation._rowId});
                         annotationsFactory.remove(currAnnotation._id, scope.$parent.subject);
@@ -142,7 +140,7 @@
                 });
 
                 getAnnotations();
-            }
+            } // end link
         };
     }]);
 

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -58,7 +58,7 @@
                                 x: header.x,
                                 y: row.y,
                                 rotation: header.rotation,
-                                type: 'row_tmp' // actual row annotations need to be called something else for now --STI
+                                type: 'row_annotation' // actual row annotations need to be called something else for now --STI
                             };
 
                             var existing = _.find(scope.annotations, { _id: tempCells[index] });
@@ -156,8 +156,11 @@
             element.bind('mousedown', function (e) {
               e.stopPropagation();
               var annotation = $parse(attrs.annotation)(scope);
-              console.log('ANNOTATION.TYPE = ', annotation.type); // --STI
-              confirmationModalFactory.deployModal('Delete annotation?', function(isConfirmed){
+              var message = 'Delete annotation?'
+              if(annotation.type == 'row_annotation') {
+                message = 'Delete entire row?';
+              }
+              confirmationModalFactory.deployModal(message, function(isConfirmed){
                 if(isConfirmed){
                   scope.$parent.removeAnnotation(annotation);
                 }

--- a/app/modules/annotation/scripts/annotations-directive.js
+++ b/app/modules/annotation/scripts/annotations-directive.js
@@ -29,14 +29,11 @@
                 };
 
                 var storeAnnotations = function (e, data) {
-                    console.log('storeAnnotations(), data = ', data);
                     // skip for row annotation: createCells() called separately
                     if (data.type === 'row') {
-                      console.log('CREATING CELLS!');
                       createCells(data);
                     }
                     else {
-                      console.log('SINGLE SELL');
                       var existing = _.find(scope.annotations, {_id: data._id});
                       if (angular.isUndefined(existing)) {
                           addAnnotation(data);
@@ -50,7 +47,6 @@
                 var tempCells = {};
 
                 var createCells = function (row) {
-                    console.log('createCells(), row = ', row);
                     var headers = _.where(scope.annotations, {type: 'header'});
                     var rowId = _.uniqueId('row_'); // + new Date().getTime(); // use human-readable id for debugging --STI
                     _.each(headers, function (header, index) {
@@ -62,7 +58,7 @@
                                 x: header.x,
                                 y: row.y,
                                 rotation: header.rotation,
-                                type: 'row'
+                                type: 'row_tmp' // actual row annotations need to be called something else for now --STI
                             };
 
                             var existing = _.find(scope.annotations, { _id: tempCells[index] });
@@ -136,15 +132,15 @@
                 scope.$on('svgDrawing:update', storeAnnotations);
 
                 scope.$on('svgDrawing:update', function (e, rect, data) {
-                    if (data.type === 'row') {
-                        // createCells(rect);
-                    }
+                    // if (data.type === 'row') {
+                    //     createCells(rect); // this doesn't seem necessary anymore
+                    // }
                 });
 
                 scope.$on('svgDrawing:finish', function (e, rect, data) {
-                    if (data.type === 'row') {
-                        // createCells(rect);
-                    }
+                    // if (data.type === 'row') {
+                    //     createCells(rect); // this doesn't seem necessary anymore
+                    // }
                     tempCells = {};
                 });
 

--- a/app/modules/annotation/scripts/annotations-factory-service.js
+++ b/app/modules/annotation/scripts/annotations-factory-service.js
@@ -80,9 +80,10 @@
             var classification = localStorageService.get(storageKey);
 
             if (classification.annotations.length === 0) {
-
-                confirmationModalFactory.deployModal({message: 'You haven\'t added any annotations, are you sure you want to finish?'}, function(isConfirmed){
-                  if(isConfirmed){
+                var params = {message: 'You haven\'t added any annotations, are you sure you want to finish?'};
+                confirmationModalFactory.setParams(params);
+                confirmationModalFactory.deployModal( function(deleteType) {
+                  if(deleteType){
                     var subject_set_queue = localStorageService.get('subject_set_queue_' + $stateParams.subject_set_id);
                     _.remove(subject_set_queue, {id: id});
                     localStorageService.set('subject_set_queue_' + $stateParams.subject_set_id, subject_set_queue);

--- a/app/modules/annotation/scripts/annotations-factory-service.js
+++ b/app/modules/annotation/scripts/annotations-factory-service.js
@@ -81,7 +81,7 @@
 
             if (classification.annotations.length === 0) {
 
-                confirmationModalFactory.deployModal('You haven\'t added any annotations, are you sure you want to finish?', function(isConfirmed){
+                confirmationModalFactory.deployModal({message: 'You haven\'t added any annotations, are you sure you want to finish?'}, function(isConfirmed){
                   if(isConfirmed){
                     var subject_set_queue = localStorageService.get('subject_set_queue_' + $stateParams.subject_set_id);
                     _.remove(subject_set_queue, {id: id});

--- a/app/modules/confirmationModal/scripts/confirmation-modal-controller.js
+++ b/app/modules/confirmationModal/scripts/confirmation-modal-controller.js
@@ -5,7 +5,15 @@
 
     module.controller('ConfirmationModalController', function(confirmationModalFactory, $scope){
 
-      $scope.msg = confirmationModalFactory.getMessage();
+      $scope.params = confirmationModalFactory.getParams();
+
+      $scope.deleteAnnotation = function() {
+        $scope.$close('annotation');
+      }
+
+      $scope.deleteRow = function() {
+        $scope.$close('row');
+      }
 
       $scope.confirm = function() {
         $scope.$close(true);

--- a/app/modules/confirmationModal/scripts/confirmation-modal-controller.js
+++ b/app/modules/confirmationModal/scripts/confirmation-modal-controller.js
@@ -16,7 +16,7 @@
       }
 
       $scope.confirm = function() {
-        $scope.$close(true);
+        $scope.$close('annotation');
       }
 
       $scope.cancel = function() {

--- a/app/modules/confirmationModal/scripts/confirmation-modal-controller.js
+++ b/app/modules/confirmationModal/scripts/confirmation-modal-controller.js
@@ -9,19 +9,19 @@
 
       $scope.deleteAnnotation = function() {
         $scope.$close('annotation');
-      }
+      };
 
       $scope.deleteRow = function() {
         $scope.$close('row');
-      }
+      };
 
       $scope.confirm = function() {
         $scope.$close('annotation');
-      }
+      };
 
       $scope.cancel = function() {
         $scope.$close(false);
-      }
+      };
 
     });
 

--- a/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
+++ b/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
@@ -25,8 +25,8 @@
           controller: 'ConfirmationModalController'
         });
 
-        modalInstance.result.then( function(isConfirmed) {
-          callback(isConfirmed);
+        modalInstance.result.then( function(deleteType) {
+          callback(deleteType);
         });
       };
 

--- a/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
+++ b/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
@@ -11,6 +11,7 @@
       };
 
       var setParams = function(data) {
+        console.log('Setting params..');
         params = data;
       }
 
@@ -18,15 +19,14 @@
         return params;
       }
 
-      var deployModal = function(data, callback) {
-        setParams(data);
+      var deployModal = function(callback) {
 
         var modalInstance = $modal.open({
           templateUrl: 'templates/confirmation-modal.html',
           controller: 'ConfirmationModalController'
         });
 
-        modalInstance.result.then(function(isConfirmed) {
+        modalInstance.result.then( function(isConfirmed) {
           callback(isConfirmed);
         });
       }

--- a/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
+++ b/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
@@ -5,23 +5,25 @@
 
     module.factory('confirmationModalFactory', [ '$modal', '$controller', function($modal,$controller){
 
-      var message = 'Are you sure?'; // set default message
+      // set default parameters
+      var params = {
+        message: 'Are you sure?'
+      };
 
-      var setMessage = function(msg) {
-        message = msg;
+      var setParams = function(data) {
+        params = data;
       }
 
-      var getMessage = function() {
-        return message;
+      var getParams = function() {
+        return params;
       }
 
-      var deployModal = function(msg, callback) {
-        setMessage(msg);
+      var deployModal = function(data, callback) {
+        setParams(data);
 
         var modalInstance = $modal.open({
           templateUrl: 'templates/confirmation-modal.html',
-          controller: 'ConfirmationModalController',
-          size: 'sm'
+          controller: 'ConfirmationModalController'
         });
 
         modalInstance.result.then(function(isConfirmed) {
@@ -31,9 +33,8 @@
 
       return {
         deployModal: deployModal,
-        message: message,
-        setMessage: setMessage,
-        getMessage: getMessage
+        setParams: setParams,
+        getParams: getParams
       };
 
     }]);

--- a/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
+++ b/app/modules/confirmationModal/scripts/confirmation-modal-factory-service.js
@@ -11,13 +11,12 @@
       };
 
       var setParams = function(data) {
-        console.log('Setting params..');
         params = data;
-      }
+      };
 
       var getParams = function() {
         return params;
-      }
+      };
 
       var deployModal = function(callback) {
 
@@ -29,7 +28,7 @@
         modalInstance.result.then( function(isConfirmed) {
           callback(isConfirmed);
         });
-      }
+      };
 
       return {
         deployModal: deployModal,

--- a/app/modules/confirmationModal/templates/confirmation-modal.html
+++ b/app/modules/confirmationModal/templates/confirmation-modal.html
@@ -5,12 +5,8 @@
 </div>
 
 <div class="modal-footer">
-  <!-- <button ng-click="confirm()" class="btn">Yes</button>
-  <button ng-click="cancel()"  class="btn">No</button> -->
-
-  <button ng-click="deleteAnnotation()" class="btn btn-teal small">Annotation</button>
-  <button ng-click="deleteRow()"        class="btn btn-teal small">Row</button>
-
-
-  <button ng-click="cancel()"           class="btn btn-skeleton teal small">Cancel</button>
+  <button ng-show="{{params.deleteType !== 'row'}}" ng-click="confirm()"          class="btn btn-teal small">Yes</button>
+  <button ng-show="{{params.deleteType === 'row'}}" ng-click="deleteAnnotation()" class="btn btn-teal small">Annotation</button>
+  <button ng-show="{{params.deleteType === 'row'}}" ng-click="deleteRow()"        class="btn btn-teal small">Row</button>
+  <button                                           ng-click="cancel()"           class="btn btn-skeleton teal small">Cancel</button>
 </div>

--- a/app/modules/confirmationModal/templates/confirmation-modal.html
+++ b/app/modules/confirmationModal/templates/confirmation-modal.html
@@ -1,10 +1,16 @@
 <div class="modal-header" ng-controller="ConfirmationModalController">
   <div class="modal-title">
-    <h3>{{msg}}</h3>
+    <h3>{{params.message}}</h3>
   </div>
 </div>
 
 <div class="modal-footer">
-  <button ng-click="confirm()" class="btn">Yes</button>
-  <button ng-click="cancel()"  class="btn">No</button>
+  <!-- <button ng-click="confirm()" class="btn">Yes</button>
+  <button ng-click="cancel()"  class="btn">No</button> -->
+
+  <button ng-click="deleteAnnotation()" class="btn btn-teal small">Annotation</button>
+  <button ng-click="deleteRow()"        class="btn btn-teal small">Row</button>
+
+
+  <button ng-click="cancel()"           class="btn btn-skeleton teal small">Cancel</button>
 </div>

--- a/app/modules/svg/scripts/svg-drawing-factory-service.js
+++ b/app/modules/svg/scripts/svg-drawing-factory-service.js
@@ -20,6 +20,7 @@
         };
 
         var bindMouseEvents = function (data) {
+            console.log('bindMouseEvents()');
             if (angular.isDefined(data)) {
                 self.data = data;
             } else {
@@ -46,15 +47,16 @@
         };
 
         var startDraw = function (event) {
-            console.log('startDraw()');
+            console.log('>>>>>> mousedown <<<<<<');
             // Only start drawing if panZoom is disabled, and it's a primary mouse click
             if (!svgPanZoomFactory.status() && event.which === 1) {
                 event.preventDefault();
+                event.stopPropagation();
 
                 if (self.drawing) {
                     console.log(' ...drawing');
                     draw(event);
-                    finishDraw(event);
+                    // finishDraw(event);
                 } else {
                     console.log(' ...else');
                     self.tempOrigin = svgService.createPoint(self.el, self.$viewport, event);
@@ -74,6 +76,7 @@
 
         var draw = function (event) {
             console.log('draw()');
+            return;
             var newPoint = svgService.createPoint(self.el, self.$viewport, event);
             self.tempRect.x = (self.tempOrigin.x < newPoint.x) ? self.tempOrigin.x : newPoint.x;
             self.tempRect.y = (self.tempOrigin.y < newPoint.y) ? self.tempOrigin.y : newPoint.y;
@@ -83,16 +86,17 @@
         };
 
         var finishDraw = function (event) {
-            console.log('finishDraw()');
+            console.log('>>>>>> mouseup <<<<<<');
             var newPoint = svgService.createPoint(self.el, self.$viewport, event);
             if (self.tempOrigin && !(newPoint.x === self.tempOrigin.x && newPoint.y === self.tempOrigin.y)) {
                 $rootScope.$broadcast('svgDrawing:finish', angular.extend({}, self.tempRect), self.data);
                 self.drawing = false;
                 self.tempRect = null;
                 self.tempOrigin = null;
+                console.log('branch #1');
             } else {
+                console.log('branch #2');
                 // TODO: Add a marker here.
-                console.log('ADD MARKER');
                 return;
             }
             self.$viewport.off('mousemove');

--- a/app/modules/svg/scripts/svg-drawing-factory-service.js
+++ b/app/modules/svg/scripts/svg-drawing-factory-service.js
@@ -50,11 +50,10 @@
             // Only start drawing if panZoom is disabled, and it's a primary mouse click
             if (!svgPanZoomFactory.status() && event.which === 1) {
                 event.preventDefault();
-                event.stopPropagation();
 
-                if (self.drawing) {
+                if (self.drawing) { // already drawing...
                     draw(event);
-                    finishDraw(event);
+                    // finishDraw(event); // not necessary?
                 } else {
                     self.tempOrigin = svgService.createPoint(self.el, self.$viewport, event);
                     self.drawing = true;

--- a/app/modules/svg/scripts/svg-drawing-factory-service.js
+++ b/app/modules/svg/scripts/svg-drawing-factory-service.js
@@ -60,7 +60,7 @@
                         width: 0,
                         height: 0,
                         timestamp: new Date().getTime(),
-                        _id: _.uniqueId() + new Date().getTime(),
+                        _id: _.uniqueId('antn_'), //+ new Date().getTime(), // use human-readable id for debugging --STI
                         rotation: svgPanZoomFactory.getRotation()
                     }, self.data);
                     $rootScope.$broadcast('svgDrawing:add', self.tempRect, self.data);

--- a/app/modules/svg/scripts/svg-drawing-factory-service.js
+++ b/app/modules/svg/scripts/svg-drawing-factory-service.js
@@ -20,7 +20,6 @@
         };
 
         var bindMouseEvents = function (data) {
-            console.log('bindMouseEvents()');
             if (angular.isDefined(data)) {
                 self.data = data;
             } else {
@@ -47,18 +46,16 @@
         };
 
         var startDraw = function (event) {
-            console.log('>>>>>> mousedown <<<<<<');
+            console.log('>>>>>> mousedown <<<<<<'); // --STI
             // Only start drawing if panZoom is disabled, and it's a primary mouse click
             if (!svgPanZoomFactory.status() && event.which === 1) {
                 event.preventDefault();
                 event.stopPropagation();
 
                 if (self.drawing) {
-                    console.log(' ...drawing');
                     draw(event);
-                    // finishDraw(event);
+                    finishDraw(event);
                 } else {
-                    console.log(' ...else');
                     self.tempOrigin = svgService.createPoint(self.el, self.$viewport, event);
                     self.drawing = true;
                     self.tempRect = angular.extend({}, self.tempOrigin, {
@@ -75,8 +72,7 @@
         };
 
         var draw = function (event) {
-            console.log('draw()');
-            return;
+            console.log('draw()'); // --STI
             var newPoint = svgService.createPoint(self.el, self.$viewport, event);
             self.tempRect.x = (self.tempOrigin.x < newPoint.x) ? self.tempOrigin.x : newPoint.x;
             self.tempRect.y = (self.tempOrigin.y < newPoint.y) ? self.tempOrigin.y : newPoint.y;
@@ -86,16 +82,14 @@
         };
 
         var finishDraw = function (event) {
-            console.log('>>>>>> mouseup <<<<<<');
+            console.log('>>>>>> mouseup <<<<<<'); // --STI
             var newPoint = svgService.createPoint(self.el, self.$viewport, event);
             if (self.tempOrigin && !(newPoint.x === self.tempOrigin.x && newPoint.y === self.tempOrigin.y)) {
                 $rootScope.$broadcast('svgDrawing:finish', angular.extend({}, self.tempRect), self.data);
                 self.drawing = false;
                 self.tempRect = null;
                 self.tempOrigin = null;
-                console.log('branch #1');
-            } else {
-                console.log('branch #2');
+            } else { // zero-dimension rect created
                 // TODO: Add a marker here.
                 return;
             }

--- a/app/modules/svg/scripts/svg-drawing-factory-service.js
+++ b/app/modules/svg/scripts/svg-drawing-factory-service.js
@@ -19,6 +19,53 @@
             self.$viewport = $viewport;
         };
 
+        var draw = function (event) {
+            var newPoint = svgService.createPoint(self.el, self.$viewport, event);
+            self.tempRect.x = (self.tempOrigin.x < newPoint.x) ? self.tempOrigin.x : newPoint.x;
+            self.tempRect.y = (self.tempOrigin.y < newPoint.y) ? self.tempOrigin.y : newPoint.y;
+            self.tempRect.width = Math.abs(newPoint.x - self.tempOrigin.x);
+            self.tempRect.height = Math.abs(newPoint.y - self.tempOrigin.y);
+            $rootScope.$broadcast('svgDrawing:update', self.tempRect, self.data);
+        };
+        
+        var startDraw = function (event) {
+            // Only start drawing if panZoom is disabled, and it's a primary mouse click
+            if (!svgPanZoomFactory.status() && event.which === 1) {
+                event.preventDefault();
+
+                if (self.drawing) { // already drawing...
+                    draw(event);
+                    // finishDraw(event); // not necessary?
+                } else {
+                    self.tempOrigin = svgService.createPoint(self.el, self.$viewport, event);
+                    self.drawing = true;
+                    self.tempRect = angular.extend({}, self.tempOrigin, {
+                        width: 0,
+                        height: 0,
+                        timestamp: new Date().getTime(),
+                        _id: _.uniqueId('antn_'), //+ new Date().getTime(), // use human-readable id for debugging --STI
+                        rotation: svgPanZoomFactory.getRotation()
+                    }, self.data);
+                    $rootScope.$broadcast('svgDrawing:add', self.tempRect, self.data);
+                    self.$viewport.on('mousemove', draw);
+                }
+            }
+        };
+
+        var finishDraw = function (event) {
+            var newPoint = svgService.createPoint(self.el, self.$viewport, event);
+            if (self.tempOrigin && !(newPoint.x === self.tempOrigin.x && newPoint.y === self.tempOrigin.y)) {
+                $rootScope.$broadcast('svgDrawing:finish', angular.extend({}, self.tempRect), self.data);
+                self.drawing = false;
+                self.tempRect = null;
+                self.tempOrigin = null;
+            } else { // zero-dimension rect created
+                // TODO: Add a marker here.
+                return;
+            }
+            self.$viewport.off('mousemove');
+        };
+
         var bindMouseEvents = function (data) {
             if (angular.isDefined(data)) {
                 self.data = data;
@@ -43,56 +90,6 @@
 
         var hasMouseEvents = function () {
             return self.eventsBound;
-        };
-
-        var startDraw = function (event) {
-            console.log('>>>>>> mousedown <<<<<<'); // --STI
-            // Only start drawing if panZoom is disabled, and it's a primary mouse click
-            if (!svgPanZoomFactory.status() && event.which === 1) {
-                event.preventDefault();
-
-                if (self.drawing) { // already drawing...
-                    draw(event);
-                    // finishDraw(event); // not necessary?
-                } else {
-                    self.tempOrigin = svgService.createPoint(self.el, self.$viewport, event);
-                    self.drawing = true;
-                    self.tempRect = angular.extend({}, self.tempOrigin, {
-                        width: 0,
-                        height: 0,
-                        timestamp: new Date().getTime(),
-                        _id: _.uniqueId('antn_'), //+ new Date().getTime(), // use human-readable id for debugging --STI
-                        rotation: svgPanZoomFactory.getRotation()
-                    }, self.data);
-                    $rootScope.$broadcast('svgDrawing:add', self.tempRect, self.data);
-                    self.$viewport.on('mousemove', draw);
-                }
-            }
-        };
-
-        var draw = function (event) {
-            console.log('draw()'); // --STI
-            var newPoint = svgService.createPoint(self.el, self.$viewport, event);
-            self.tempRect.x = (self.tempOrigin.x < newPoint.x) ? self.tempOrigin.x : newPoint.x;
-            self.tempRect.y = (self.tempOrigin.y < newPoint.y) ? self.tempOrigin.y : newPoint.y;
-            self.tempRect.width = Math.abs(newPoint.x - self.tempOrigin.x);
-            self.tempRect.height = Math.abs(newPoint.y - self.tempOrigin.y);
-            $rootScope.$broadcast('svgDrawing:update', self.tempRect, self.data);
-        };
-
-        var finishDraw = function (event) {
-            console.log('>>>>>> mouseup <<<<<<'); // --STI
-            var newPoint = svgService.createPoint(self.el, self.$viewport, event);
-            if (self.tempOrigin && !(newPoint.x === self.tempOrigin.x && newPoint.y === self.tempOrigin.y)) {
-                $rootScope.$broadcast('svgDrawing:finish', angular.extend({}, self.tempRect), self.data);
-                self.drawing = false;
-                self.tempRect = null;
-                self.tempOrigin = null;
-            } else { // zero-dimension rect created
-                // TODO: Add a marker here.
-                return;
-            }
-            self.$viewport.off('mousemove');
         };
 
         return {

--- a/app/modules/svg/scripts/svg-drawing-factory-service.js
+++ b/app/modules/svg/scripts/svg-drawing-factory-service.js
@@ -46,15 +46,18 @@
         };
 
         var startDraw = function (event) {
+            console.log('startDraw()');
             // Only start drawing if panZoom is disabled, and it's a primary mouse click
             if (!svgPanZoomFactory.status() && event.which === 1) {
                 event.preventDefault();
 
                 if (self.drawing) {
+                    console.log(' ...drawing');
                     draw(event);
                     finishDraw(event);
                 } else {
-                    self.tempOrigin = svgService.getPoint(self.el, self.$viewport, event);
+                    console.log(' ...else');
+                    self.tempOrigin = svgService.createPoint(self.el, self.$viewport, event);
                     self.drawing = true;
                     self.tempRect = angular.extend({}, self.tempOrigin, {
                         width: 0,
@@ -70,7 +73,8 @@
         };
 
         var draw = function (event) {
-            var newPoint = svgService.getPoint(self.el, self.$viewport, event);
+            console.log('draw()');
+            var newPoint = svgService.createPoint(self.el, self.$viewport, event);
             self.tempRect.x = (self.tempOrigin.x < newPoint.x) ? self.tempOrigin.x : newPoint.x;
             self.tempRect.y = (self.tempOrigin.y < newPoint.y) ? self.tempOrigin.y : newPoint.y;
             self.tempRect.width = Math.abs(newPoint.x - self.tempOrigin.x);
@@ -79,7 +83,8 @@
         };
 
         var finishDraw = function (event) {
-            var newPoint = svgService.getPoint(self.el, self.$viewport, event);
+            console.log('finishDraw()');
+            var newPoint = svgService.createPoint(self.el, self.$viewport, event);
             if (self.tempOrigin && !(newPoint.x === self.tempOrigin.x && newPoint.y === self.tempOrigin.y)) {
                 $rootScope.$broadcast('svgDrawing:finish', angular.extend({}, self.tempRect), self.data);
                 self.drawing = false;
@@ -87,6 +92,7 @@
                 self.tempOrigin = null;
             } else {
                 // TODO: Add a marker here.
+                console.log('ADD MARKER');
                 return;
             }
             self.$viewport.off('mousemove');

--- a/app/modules/svg/scripts/svg-grid-factory-service.js
+++ b/app/modules/svg/scripts/svg-grid-factory-service.js
@@ -22,8 +22,8 @@
                 self.data = null;
             }
 
-            // self.$viewport.on('mousedown', startDraw);
-            // self.$viewport.on('mouseup', finishDraw);
+            self.$viewport.on('mousedown', startDraw);
+            self.$viewport.on('mouseup', finishDraw);
 
             self.eventsBound = true;
         };

--- a/app/modules/svg/scripts/svg-service.js
+++ b/app/modules/svg/scripts/svg-service.js
@@ -4,7 +4,7 @@
     var module = angular.module('svg');
 
     module.service('svgService', function () {
-        this.getPoint = function (el, $viewport, event) {
+        this.createPoint = function (el, $viewport, event) {
             var point = el.createSVGPoint();
             point.x = event.clientX;
             point.y = event.clientY;

--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -502,39 +502,39 @@
         $rootScope.bodyClass = 'annotate';
 
         $scope.loadSubject = function () {
-            $rootScope.$broadcast('transcribe:loadingSubject');
+          $rootScope.$broadcast('transcribe:loadingSubject');
 
-            $scope.subject_set_id = $stateParams.subject_set_id;
-            $scope.subject = undefined;
-            $scope.isLoading = true;
-            $scope.questions = null;
-            $scope.questionsComplete = false;
-            $scope.grid = gridFactory.get;
+          $scope.subject_set_id = $stateParams.subject_set_id;
+          $scope.subject = undefined;
+          $scope.isLoading = true;
+          $scope.questions = null;
+          $scope.questionsComplete = false;
+          $scope.grid = gridFactory.get;
 
-            workflowFactory.get($scope.subject_set_id)
-                .then(function (response) {
-                    $scope.questions = response;
+          workflowFactory.get($scope.subject_set_id)
+            .then(function (response) {
+              $scope.questions = response;
+            });
+
+          subjectFactory.get($scope.subject_set_id)
+            .then(function (response) {
+              if (response !== null) {
+                $timeout(function () {
+                  $scope.subject = response;
+                  var keys = Object.keys($scope.subject.locations[0]);
+                  var subjectImage = $scope.subject.locations[0][keys[0]];
+                  // TODO: change this. We're cache busting the image.onload event.
+                  subjectImage += '?' + new Date().getTime();
+                  $scope.trustedSubjectImage = $sce.trustAsResourceUrl(subjectImage);
+                  $scope.loadHandler = $scope.subjectLoaded();
+                  $rootScope.$broadcast('transcribe:loadedSubject');
                 });
+              } else {
+                $scope.subject = null;
+                $rootScope.$broadcast('transcribe:loadedSubject');
+              }
 
-            subjectFactory.get($scope.subject_set_id)
-                .then(function (response) {
-                    if (response !== null) {
-                        $timeout(function () {
-                            $scope.subject = response;
-                            var keys = Object.keys($scope.subject.locations[0]);
-                            var subjectImage = $scope.subject.locations[0][keys[0]];
-                            // TODO: change this. We're cache busting the image.onload event.
-                            subjectImage += '?' + new Date().getTime();
-                            $scope.trustedSubjectImage = $sce.trustAsResourceUrl(subjectImage);
-                            $scope.loadHandler = $scope.subjectLoaded();
-                            $rootScope.$broadcast('transcribe:loadedSubject');
-                        });
-                    } else {
-                        $scope.subject = null;
-                        $rootScope.$broadcast('transcribe:loadedSubject');
-                    }
-
-                });
+            });
         };
         $scope.loadSubject();
 

--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -125,6 +125,7 @@
                     if (_.isNull(scope.$parent.activeTool)) {
                         toolFactory.disable();
                     } else {
+                        console.log('ENABLE'); // --STI
                         toolFactory.enable(thisTool.id);
                     }
                 };
@@ -236,10 +237,12 @@
                 });
 
                 scope.$watch('activeTask', function () {
+                    console.log('activeTask changed, activeTask = ', scope.activeTask); // --STI
 
                     // Skip grid tasks if we're not logged in
                     if (scope.activeTask && scope.tasks[scope.activeTask].grid && !authFactory.getUser()) {
                         scope.confirm(scope.tasks[scope.activeTask].skip);
+                        return; // prevent duplicate event bindings after skipping task --STI
                     }
 
                     if (scope.activeTask && angular.isDefined(scope.tasks[scope.activeTask].tools)) {

--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -234,13 +234,12 @@
                 });
 
                 scope.$watch('activeTask', function () {
-                    console.log('activeTask changed, activeTask = ', scope.activeTask); // --STI
                     toolFactory.disable(); // reset mouse events (removes duplicates)
 
                     // Skip grid tasks if we're not logged in
                     if (scope.activeTask && scope.tasks[scope.activeTask].grid && !authFactory.getUser()) {
                         scope.confirm(scope.tasks[scope.activeTask].skip);
-                        return; // prevent duplicate event bindings after skipping task --STI
+                        return; // prevent duplicate event bindings after skipping task
                     }
 
                     if (scope.activeTask && angular.isDefined(scope.tasks[scope.activeTask].tools)) {

--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -235,6 +235,7 @@
 
                 scope.$watch('activeTask', function () {
                     console.log('activeTask changed, activeTask = ', scope.activeTask); // --STI
+                    toolFactory.disable(); // reset mouse events (removes duplicates)
 
                     // Skip grid tasks if we're not logged in
                     if (scope.activeTask && scope.tasks[scope.activeTask].grid && !authFactory.getUser()) {

--- a/app/modules/transcribe/scripts/init.js
+++ b/app/modules/transcribe/scripts/init.js
@@ -125,7 +125,6 @@
                     if (_.isNull(scope.$parent.activeTool)) {
                         toolFactory.disable();
                     } else {
-                        console.log('ENABLE'); // --STI
                         toolFactory.enable(thisTool.id);
                     }
                 };
@@ -213,9 +212,7 @@
             localStorageService.set('grids', _grids);
         }
 
-
     });
-
 
     module.directive('transcribeQuestions', function ($rootScope, $timeout, annotationsFactory, gridFactory, toolFactory, authFactory) {
         return {
@@ -251,14 +248,15 @@
                         toolFactory.disable();
                     }
 
-                    if (scope.activeTask === 'T5-use-grid') {
-                        if (gridFactory.list().length === 0) {
-                            scope.confirm(scope.tasks[scope.activeTask].skip);
-                        } else {
-                            scope.grids = gridFactory.list();
-                            scope.showGrid(0);
-                        }
-                    }
+                    // /* COMMENT FOR NOW */
+                    // if (scope.activeTask === 'T5-use-grid') {
+                    //     if (gridFactory.list().length === 0) {
+                    //         scope.confirm(scope.tasks[scope.activeTask].skip);
+                    //     } else {
+                    //         scope.grids = gridFactory.list();
+                    //         scope.showGrid(0);
+                    //     }
+                    // }
 
                 });
 

--- a/app/modules/tutorial/scripts/init.js
+++ b/app/modules/tutorial/scripts/init.js
@@ -28,13 +28,12 @@
       ];
 
       $scope.launchTutorial = function() {
-        // console.log('LAUNCH TUTORIAL!');
         var modalInstance = $modal.open({
           templateUrl: 'templates/tutorial.html',
           controller: 'TutorialController',
           size: 'lg'
         });
-      }
+      };
 
     }]);
 

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,37 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/local/bin/node', '/usr/local/bin/npm', 'run', 'test' ]
+2 info using npm@2.14.7
+3 info using node@v5.11.0
+4 verbose run-script [ 'pretest', 'test', 'posttest' ]
+5 info pretest oldweather@0.1.0
+6 info test oldweather@0.1.0
+7 verbose unsafe-perm in lifecycle true
+8 info oldweather@0.1.0 Failed to exec test script
+9 verbose stack Error: oldweather@0.1.0 test: `gulp test-ci`
+9 verbose stack Exit status 1
+9 verbose stack     at EventEmitter.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/lifecycle.js:214:16)
+9 verbose stack     at emitTwo (events.js:100:13)
+9 verbose stack     at EventEmitter.emit (events.js:185:7)
+9 verbose stack     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/spawn.js:24:14)
+9 verbose stack     at emitTwo (events.js:100:13)
+9 verbose stack     at ChildProcess.emit (events.js:185:7)
+9 verbose stack     at maybeClose (internal/child_process.js:850:16)
+9 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:5)
+10 verbose pkgid oldweather@0.1.0
+11 verbose cwd /Users/sascha/Documents/Zooniverse/old-weather
+12 error Darwin 15.6.0
+13 error argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "test"
+14 error node v5.11.0
+15 error npm  v2.14.7
+16 error code ELIFECYCLE
+17 error oldweather@0.1.0 test: `gulp test-ci`
+17 error Exit status 1
+18 error Failed at the oldweather@0.1.0 test script 'gulp test-ci'.
+18 error This is most likely a problem with the oldweather package,
+18 error not with npm itself.
+18 error Tell the author that this fails on your system:
+18 error     gulp test-ci
+18 error You can get their info via:
+18 error     npm owner ls oldweather
+18 error There is likely additional logging output above.
+19 verbose exit [ 1, true ]

--- a/styl/main.styl
+++ b/styl/main.styl
@@ -589,6 +589,9 @@ img
         opacity 0.7
 
 .btn
+    &.small
+      font-weight: 200
+      padding: 6px 12px
     border: 0
     font-weight: 700
     padding: 11px 28px


### PR DESCRIPTION
Enables users to delete entire rows at a time, instead of having to delete each annotation individually. Resolves issues #92, #124.

Note: As before, each annotation can be deleted separately by clicking on it. However, when deleting an annotation that belongs to a row, I was forced to add a UI to clarify what the user wants to do: delete a single annotation or an entire row? (see below) 

<img width="752" alt="screen shot 2016-08-23 at 1 48 05 pm" src="https://cloud.githubusercontent.com/assets/5863630/17909398/339a8d6a-6939-11e6-8616-4b53d6eb5818.png">

You click on individual annotations to delete them, or the rows containing them. There's no other way to distinguish. One solution would be to introduce a "delete" button on each annotation and an additional button at the end of each row.
